### PR TITLE
Update version to 1.0.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@
 - **Interfaz móvil** optimizada
 
 ### 🚀 Estado del Deploy
-- **Versión actual:** v1.0.0
-- **Último deploy:** 28 de julio de 2025, 15:27
+- **Versión actual:** v1.0.1
+- **Último deploy:** 29 de julio de 2025, 19:47
 - **Branch:** firebase-v9-migration
 - **URL:** https://felipeaurelio13.github.io/plantitas-app/
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "plant-care-companion",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "plant-care-companion",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "dependencies": {
         "@juggle/resize-observer": "^3.4.0",
         "@radix-ui/react-switch": "^1.2.5",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "plant-care-companion",
   "private": true,
-  "version": "1.0.0",
+  "version": "1.0.1",
   "homepage": "https://felipeaurelio13.github.io/plantitas-app",
   "type": "module",
   "scripts": {

--- a/src/config/version.ts
+++ b/src/config/version.ts
@@ -1,9 +1,9 @@
 // Configuración de versión de la aplicación
 // Este archivo se actualiza automáticamente en cada build
 
-export const APP_VERSION = '1.0.0';
-export const BUILD_TIMESTAMP = '2025-07-28T16:36:19.704Z';
-export const BUILD_DATE = '28 de julio de 2025, 16:36';
+export const APP_VERSION = '1.0.1';
+export const BUILD_TIMESTAMP = '2025-07-29T19:47:49.527Z';
+export const BUILD_DATE = '29 de julio de 2025, 19:47';
 
 // Información adicional de la aplicación
 export const APP_INFO = {


### PR DESCRIPTION
## Summary
- bump to version 1.0.1 using `npm version`
- update build date in version config
- document new version and deploy date in README

## Testing
- `npm test` *(fails: several test suites fail)*
- `npm run lint` *(fails: 686 errors)*

------
https://chatgpt.com/codex/tasks/task_e_688925067f34832499ac64c781f17e93