### PR TITLE
Fix loading issue and show version everywhere

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@
 - **Interfaz móvil** optimizada
 
 ### 🚀 Estado del Deploy
-- **Versión actual:** v1.0.2
-- **Último deploy:** 30 de julio de 2025, 22:10
+- **Versión actual:** v1.0.3
+- **Último deploy:** 29 de July de 2025, 23:10
 - **Branch:** firebase-v9-migration
 - **URL:** https://felipeaurelio13.github.io/plantitas-app/
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "plant-care-companion",
-  "version": "1.0.1",
+  "version": "1.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "plant-care-companion",
-      "version": "1.0.1",
+      "version": "1.0.3",
       "dependencies": {
         "@juggle/resize-observer": "^3.4.0",
         "@radix-ui/react-switch": "^1.2.5",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "plant-care-companion",
   "private": true,
-  "version": "1.0.2",
+  "version": "1.0.3",
   "homepage": "https://felipeaurelio13.github.io/plantitas-app",
   "type": "module",
   "scripts": {

--- a/src/components/FirebaseConfigMissing.tsx
+++ b/src/components/FirebaseConfigMissing.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { AlertTriangle, Settings, ExternalLink } from 'lucide-react';
+import Footer from './Footer';
 
 export const FirebaseConfigMissing: React.FC = () => {
   const copyEnvTemplate = () => {
@@ -99,6 +100,7 @@ VITE_OPENAI_API_KEY=your_openai_key_here`}</pre>
           </p>
         </div>
       </div>
+      <Footer className="mt-8" showVersion />
     </div>
   );
 };

--- a/src/config/version.ts
+++ b/src/config/version.ts
@@ -1,9 +1,9 @@
 // Configuración de versión de la aplicación
 // Este archivo se actualiza automáticamente en cada build
 
-export const APP_VERSION = '1.0.2';
-export const BUILD_TIMESTAMP = '2025-07-29T22:14:24.712Z';
-export const BUILD_DATE = '29 de julio de 2025, 22:14';
+export const APP_VERSION = '1.0.3';
+export const BUILD_TIMESTAMP = '2025-07-29T23:11:58.067Z';
+export const BUILD_DATE = '29 de julio de 2025, 23:11';
 
 // Información adicional de la aplicación
 export const APP_INFO = {

--- a/src/pages/Auth.tsx
+++ b/src/pages/Auth.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from 'react';
+import Footer from '../components/Footer';
 import { motion, AnimatePresence } from 'framer-motion';
 import { Mail, Lock, User, Eye, EyeOff, Leaf, Sprout, Flower2 } from 'lucide-react';
 import useAuthStore from '../stores/useAuthStore';
@@ -282,6 +283,7 @@ const AuthPage: React.FC = () => {
           </p>
         </motion.div>
       </motion.div>
+      <Footer className="mt-8" showVersion />
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- bump version to 1.0.3
- show footer with version on auth and config missing screens
- update README deploy info

## Testing
- `npm run lint` *(fails: 686 errors)*
- `npm test` *(fails: many module not found errors)*

------
https://chatgpt.com/codex/tasks/task_e_688953d0fc60832487eb07d08eceda33