### PR TITLE
Fix blank plantitas loading page

### DIFF
--- a/index.html
+++ b/index.html
@@ -142,20 +142,7 @@
     <script>
       console.log('[HTML] Emergency load started');
       
-      // Emergency loading management - forzar remoción después de 2 segundos
-      setTimeout(function() {
-        console.log('[HTML] Emergency: removing loading class');
-        if (document.documentElement.classList) {
-          document.documentElement.classList.remove('js-loading');
-        }
-        // También remover el loading screen directamente si aún existe
-        var loadingDiv = document.querySelector('.critical-loading');
-        if (loadingDiv && loadingDiv.parentNode) {
-          console.log('[HTML] Removing critical loading div');
-          loadingDiv.style.display = 'none';
-        }
-      }, 2000);
-      
+      // Mantener la pantalla de carga hasta que la app monte correctamente
       window.addEventListener('load', function() {
         console.log('[HTML] Window loaded');
         setTimeout(function() {
@@ -165,7 +152,6 @@
         }, 100);
       });
       
-      // Remover error handling que está causando problemas
       // NO interceptar errores - dejar que React los maneje
     </script>
     


### PR DESCRIPTION
Removes the premature loader hiding script to fix the blank screen issue after the "Cargando Plantitas..." message.

Previously, an "emergency" `setTimeout` in `index.html` would hide the loading screen after 2 seconds, even if the main application bundle hadn't finished loading and mounting, resulting in a blank page. The loader now correctly remains visible until the `window.load` event fires, indicating the app is ready.

---
<a href="https://cursor.com/background-agent?bcId=bc-793ec187-36ae-4c72-97d0-dec57d5d6b3c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-793ec187-36ae-4c72-97d0-dec57d5d6b3c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

